### PR TITLE
Add post-review-requirement paragraph to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Here's another paragraph, added after I made `master` protected. The
 branch requires pull request reviews before merging, except for
 administrators. Can I push directly?
 
+Hmm. Yes, I can push directly. Is it because I'm an administrator?
+OK, I've changed the configuration so we require pull request reviews
+for administrators too. Can I still push directly?
+


### PR DESCRIPTION
Now that I've configured the protected master branch to require an approving review
on a PR, I can no longer push directly to `master`. Good!

OK, here's a PR for the change I intended to push. Can I self-review?
